### PR TITLE
feat - data - update api to new url

### DIFF
--- a/data/src/main/java/com/android/jimmy/motus/data/api/MotusService.kt
+++ b/data/src/main/java/com/android/jimmy/motus/data/api/MotusService.kt
@@ -4,6 +4,6 @@ import retrofit2.Response
 import retrofit2.http.GET
 
 internal interface MotusService {
-    @GET("/raw/iys4katchhd")
+    @GET("/JimmyJMA/2fcab8bf05fb4542ad35f13041a95bd5/raw/ac758258acd4244dee75c88162b6f23a6c3534ef/gistfile1.txt")
     suspend fun getWords(): Response<String>
 }

--- a/data/src/main/java/com/android/jimmy/motus/data/api/WordRetrofit.kt
+++ b/data/src/main/java/com/android/jimmy/motus/data/api/WordRetrofit.kt
@@ -12,7 +12,7 @@ import retrofit2.converter.scalars.ScalarsConverterFactory
 @InstallIn(SingletonComponent::class)
 object WordRetrofit {
 
-    private const val BASE_URL = "https://just-paste.com/"
+    private const val BASE_URL = "https://gist.githubusercontent.com/"
 
     @Provides
     fun provideBaseUrl(): String = BASE_URL


### PR DESCRIPTION
Changement de l'API https://just-paste.com/raw/iys4katchh vers https://gist.githubusercontent.com/JimmyJMA/2fcab8bf05fb4542ad35f13041a95bd5/raw/ac758258acd4244dee75c88162b6f23a6c3534ef/gistfile1.txt

L'ancienne API est KO depuis dimanche après-midi